### PR TITLE
fix error in case of missing initiator for markdown export

### DIFF
--- a/pytest_httpdbg/__init__.py
+++ b/pytest_httpdbg/__init__.py
@@ -1,3 +1,3 @@
 from pytest_httpdbg.plugin import httpdbg_record_filename  # noqa F401
 
-__version__ = "0.10.2"
+__version__ = "0.10.3"

--- a/pytest_httpdbg/plugin.py
+++ b/pytest_httpdbg/plugin.py
@@ -43,7 +43,7 @@ def record_to_md(record, initiators):
             ```
             {initiators[record.initiator_id].short_stack}
             ```
-            """)
+            """)  # noqa W293
 
     md += dedent(f"""
         
@@ -67,7 +67,7 @@ def record_to_md(record, initiators):
         {record.response.preview.get("parsed", record.response.preview.get("text", ""))}
         ```
 
-        """)
+        """)  # noqa W293
 
     return md
 

--- a/pytest_httpdbg/plugin.py
+++ b/pytest_httpdbg/plugin.py
@@ -1,5 +1,6 @@
 import glob
 import os
+from textwrap import dedent
 import time
 from typing import Optional
 
@@ -28,37 +29,47 @@ def content_type_md(content_type):
 
 
 def record_to_md(record, initiators):
-    return f"""## {record.url}
+    md = ""
 
-### initiator
+    md += f"## {record.url}"
 
-{initiators[record.initiator_id].label}
+    if record.initiator_id in initiators:
+        md += dedent(f"""
+            
+            ### initiator
 
-```
-{initiators[record.initiator_id].short_stack}
-```
+            {initiators[record.initiator_id].label}
 
-### request
+            ```
+            {initiators[record.initiator_id].short_stack}
+            ```
+            """)
 
-```http
-{record.request.rawheaders.decode("utf-8")}
-```
+    md += dedent(f"""
+        
+        ### request
 
-```{content_type_md(record.request.get_header("Content-Type"))}
-{record.request.preview.get("parsed", record.request.preview.get("text", ""))}
-```
+        ```http
+        {record.request.rawheaders.decode("utf-8")}
+        ```
 
-### response
+        ```{content_type_md(record.request.get_header("Content-Type"))}
+        {record.request.preview.get("parsed", record.request.preview.get("text", ""))}
+        ```
 
-```http
-{record.response.rawheaders.decode("utf-8")}
-```
+        ### response
 
-```{content_type_md(record.response.get_header("Content-Type"))}
-{record.response.preview.get("parsed", record.response.preview.get("text", ""))}
-```
+        ```http
+        {record.response.rawheaders.decode("utf-8")}
+        ```
 
-"""
+        ```{content_type_md(record.response.get_header("Content-Type"))}
+        {record.response.preview.get("parsed", record.response.preview.get("text", ""))}
+        ```
+
+        """)
+
+    return md
 
 
 def pytest_addoption(parser):

--- a/pytest_httpdbg/plugin.py
+++ b/pytest_httpdbg/plugin.py
@@ -1,6 +1,5 @@
 import glob
 import os
-from textwrap import dedent
 import time
 from typing import Optional
 
@@ -29,47 +28,60 @@ def content_type_md(content_type):
 
 
 def record_to_md(record, initiators):
-    md = ""
+    md = list()
 
-    md += f"## {record.url}"
+    md.append(f"## {record.url}")
 
     if record.initiator_id in initiators:
-        md += dedent(f"""
-            
-            ### initiator
+        md.append(f"""
+### initiator
 
-            {initiators[record.initiator_id].label}
+{initiators[record.initiator_id].label}
 
-            ```
-            {initiators[record.initiator_id].short_stack}
-            ```
-            """)  # noqa W293
+```
+{initiators[record.initiator_id].short_stack}
+```
+""")
 
-    md += dedent(f"""
-        
-        ### request
+    md.append(f"""
+### request
 
-        ```http
-        {record.request.rawheaders.decode("utf-8")}
-        ```
+```http
+{record.request.rawheaders.decode("utf-8")}
+```
+""")
 
-        ```{content_type_md(record.request.get_header("Content-Type"))}
-        {record.request.preview.get("parsed", record.request.preview.get("text", ""))}
-        ```
+    request_content = record.request.preview.get(
+        "parsed", record.request.preview.get("text", "")
+    )
+    if request_content:
+        md.append(f"""
 
-        ### response
+```{content_type_md(record.request.get_header("Content-Type"))}
+{request_content}
+```
+""")
 
-        ```http
-        {record.response.rawheaders.decode("utf-8")}
-        ```
+    md.append(f"""
+### response
 
-        ```{content_type_md(record.response.get_header("Content-Type"))}
-        {record.response.preview.get("parsed", record.response.preview.get("text", ""))}
-        ```
+```http
+{record.response.rawheaders.decode("utf-8")}
+```
+""")
 
-        """)  # noqa W293
+    response_content = record.response.preview.get(
+        "parsed", record.response.preview.get("text", "")
+    )
+    if response_content:
+        md.append(f"""
+```{content_type_md(record.response.get_header("Content-Type"))}
+{response_content}
+```
 
-    return md
+""")
+
+    return "\n".join(md)
 
 
 def pytest_addoption(parser):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 flake8
 black
 pytest>7
-requests
+requests<2.34  # until httpdbg and/or requests is fixed
 build
 Jinja2
 Werkzeug

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 flake8
 black
 pytest>7
-requests<2.34  # until httpdbg and/or requests is fixed
+requests<2.34  # until httpdbg and/or requests are fixed: "You can only merge into CookieJar"
 build
 Jinja2
 Werkzeug


### PR DESCRIPTION
When exporting the HTTP traces to Markdown, file generation fails if the initiator of the requests is not defined.

The bug description is available here: https://github.com/cle-b/pytest-httpdbg/issues/23

This PR aims to prevent `pytest` from failing. It does not fix the underlying reason why the initiator of the requests is not defined.
