### PR TITLE
fix tests due to incompatibility with requests 2.34

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 flake8
 black
 pytest>7
-requests<2.34  # until httpdbg and/or requests are fixed: "You can only merge into CookieJar"
+requests
 build
 Jinja2
 Werkzeug

--- a/tests/test_allure.py
+++ b/tests/test_allure.py
@@ -56,7 +56,7 @@ def test_mode_allure(pytester, tmp_path):
             requests.post(httpbin.url + "/post", json={"a":"b"})
         """)
 
-    result = pytester.runpytest("--httpdbg-allure", f"--alluredir={tmp_path}")
+    result = pytester.runpytest_subprocess("--httpdbg-allure", f"--alluredir={tmp_path}")
 
     result.assert_outcomes(passed=2)
 
@@ -98,7 +98,7 @@ def test_mode_allure_only_on_failure(pytester, tmp_path):
             assert False
         """)
 
-    result = pytester.runpytest(
+    result = pytester.runpytest_subprocess(
         "--httpdbg-allure", f"--alluredir={tmp_path}", "--httpdbg-only-on-failure"
     )
 

--- a/tests/test_allure.py
+++ b/tests/test_allure.py
@@ -56,7 +56,9 @@ def test_mode_allure(pytester, tmp_path):
             requests.post(httpbin.url + "/post", json={"a":"b"})
         """)
 
-    result = pytester.runpytest_subprocess("--httpdbg-allure", f"--alluredir={tmp_path}")
+    result = pytester.runpytest_subprocess(
+        "--httpdbg-allure", f"--alluredir={tmp_path}"
+    )
 
     result.assert_outcomes(passed=2)
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -39,7 +39,7 @@ def test_no_httpdbg(pytester):
             requests.post(httpbin.url + "/intest")
     """)
 
-    result = pytester.runpytest()
+    result = pytester.runpytest_subprocess()
 
     result.assert_outcomes(passed=2)
 
@@ -60,7 +60,7 @@ def test_record_in_dir(pytester, tmp_path):
             requests.post(httpbin.url + "/intest")
     """)
 
-    result = pytester.runpytest("--httpdbg", "--httpdbg-dir", str(logs_dir))
+    result = pytester.runpytest_subprocess("--httpdbg", "--httpdbg-dir", str(logs_dir))
 
     result.assert_outcomes(passed=2)
 
@@ -90,7 +90,7 @@ def test_with_initiator(pytester, tmp_path):
             fakepackage.coucou(httpbin.url)
     """)
 
-    result = pytester.runpytest(
+    result = pytester.runpytest_subprocess(
         "--httpdbg",
         "--httpdbg-dir",
         str(logs_dir),
@@ -126,7 +126,7 @@ def test_without_initiator(pytester, tmp_path):
             fakepackage.coucou(httpbin.url)
     """)
 
-    result = pytester.runpytest("--httpdbg", "--httpdbg-dir", str(logs_dir))
+    result = pytester.runpytest_subprocess("--httpdbg", "--httpdbg-dir", str(logs_dir))
 
     result.assert_outcomes(passed=1)
 


### PR DESCRIPTION
This PR fixes the tests to make them compatible with `requests 2.34.2`.

With `requests 2.34`, many tests fail with the following error:

```
conftest.py:7: in fixture_session
    requests.get(httpbin.url + "/setupsession")
/home/cle/dev/pytest-httpdbg/venv/lib/python3.12/site-packages/httpdbg/hooks/requests.py:19: in hook
    ret = method(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^
/home/cle/dev/pytest-httpdbg/venv/lib/python3.12/site-packages/requests/api.py:87: in get
    return request("get", url, params=params, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/home/cle/dev/pytest-httpdbg/venv/lib/python3.12/site-packages/requests/api.py:71: in request
    return session.request(method=method, url=url, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/home/cle/dev/pytest-httpdbg/venv/lib/python3.12/site-packages/httpdbg/hooks/requests.py:19: in hook
    ret = method(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^
/home/cle/dev/pytest-httpdbg/venv/lib/python3.12/site-packages/requests/sessions.py:635: in request
    prep = self.prepare_request(req)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
/home/cle/dev/pytest-httpdbg/venv/lib/python3.12/site-packages/requests/sessions.py:532: in prepare_request
    merge_cookies(RequestsCookieJar(), self.cookies), cookies
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

cookiejar = <RequestsCookieJar[]>, cookies = <RequestsCookieJar[]>

    def merge_cookies(
        cookiejar: CookieJar, cookies: dict[str, str] | CookieJar | None
    ) -> CookieJar:
        """Add cookies to cookiejar and returns a merged CookieJar.
    
        :param cookiejar: CookieJar object to add the cookies to.
        :param cookies: Dictionary or CookieJar object to be added.
        :rtype: CookieJar
        """
        if not isinstance(cookiejar, cookielib.CookieJar):  # type: ignore[reportUnnecessaryIsInstance]  # runtime guard
>           raise ValueError("You can only merge into CookieJar")
E           ValueError: You can only merge into CookieJar

/home/cle/dev/pytest-httpdbg/venv/lib/python3.12/site-packages/requests/cookies.py:614: ValueError
```

## What's changed

To avoid the error, the `pytest` run inside `pytest` are now executed in a subprocess. 

## Verification

The tests now pass. 

